### PR TITLE
Check if Relationships for Field Values are None

### DIFF
--- a/src-python/trp/__init__.py
+++ b/src-python/trp/__init__.py
@@ -238,7 +238,7 @@ class Field(BaseBlock):
                 for eid in item['Ids']:
                     vkvs = blockMap[eid]
                     if 'VALUE' in vkvs['EntityTypes']:
-                        if ('Relationships' in vkvs):
+                        if ('Relationships' in vkvs and vkvs['Relationships'] is not None):
                             for vitem in vkvs['Relationships']:
                                 if (vitem["Type"] == "CHILD"):
                                     self._value = FieldValue(


### PR DESCRIPTION
The Textract API occasionally returns JSON payloads with `FieldValues` without `Relationships`. These JSON payloads do however set the relationships data to `null`. This change adds an extract `None` check before iterating over the relationship data for a field value.
